### PR TITLE
Start redis server only if it's available

### DIFF
--- a/instrumentation/sidekiq/Rakefile
+++ b/instrumentation/sidekiq/Rakefile
@@ -12,7 +12,8 @@ require 'rubocop/rake_task'
 RuboCop::RakeTask.new
 
 task :start_redis do
-  @redis_pid = fork { exec 'redis-server test/redis.conf' }
+  redis_exists = `which redis-server`.lines.any?
+  @redis_pid = fork { exec 'redis-server test/redis.conf' } if redis_exists
 end
 
 Rake::TestTask.new test: :start_redis do |t|


### PR DESCRIPTION
It fixes open-telemetry/opentelemetry-ruby-contrib#36.